### PR TITLE
Oprav Frýde na Frýdek

### DIFF
--- a/registry/templates/nav.html
+++ b/registry/templates/nav.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
   <a class="navbar-brand" href="{{ url_for('public.home') }}">
-    Evidence dárců ČČK Frýde-Místek
+    Evidence dárců ČČK Frýdek-Místek
   </a>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">


### PR DESCRIPTION
Na úvodní stránce je chybně uveden název města. Opraveno.