### PR TITLE
Přidej souhrnnou tabulku dárců

### DIFF
--- a/migrations/versions/217337f9b133_create_donors_overview_table.py
+++ b/migrations/versions/217337f9b133_create_donors_overview_table.py
@@ -1,0 +1,44 @@
+"""create_donors_overview_table
+
+Revision ID: 217337f9b133
+Revises: 149e19e8c994
+Create Date: 2020-09-27 10:17:45.269089
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "217337f9b133"
+down_revision = "9d51ae0ab1e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "donors_overview",
+        sa.Column("rodne_cislo", sa.String(length=10), nullable=False),
+        sa.Column("first_name", sa.String(), nullable=False),
+        sa.Column("last_name", sa.String(), nullable=False),
+        sa.Column("address", sa.String(), nullable=False),
+        sa.Column("city", sa.String(), nullable=False),
+        sa.Column("postal_code", sa.String(length=5), nullable=False),
+        sa.Column("kod_pojistovny", sa.String(length=3), nullable=False),
+        sa.Column("donation_count_fm", sa.Integer(), nullable=False),
+        sa.Column("donation_count_fm_bubenik", sa.Integer(), nullable=False),
+        sa.Column("donation_count_trinec", sa.Integer(), nullable=False),
+        sa.Column("donation_count_total", sa.Integer(), nullable=False),
+        sa.Column("donation_count_manual", sa.Integer(), nullable=False),
+        sa.Column("awarded_medal_br", sa.Boolean(), nullable=False),
+        sa.Column("awarded_medal_st", sa.Boolean(), nullable=False),
+        sa.Column("awarded_medal_zl", sa.Boolean(), nullable=False),
+        sa.Column("awarded_medal_kr3", sa.Boolean(), nullable=False),
+        sa.Column("awarded_medal_kr2", sa.Boolean(), nullable=False),
+        sa.Column("awarded_medal_kr1", sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint("rodne_cislo"),
+    )
+
+
+def downgrade():
+    op.drop_table("donors_overview")

--- a/registry/donor/models.py
+++ b/registry/donor/models.py
@@ -48,3 +48,28 @@ class AwardedMedals(db.Model):
     rodne_cislo = db.Column(db.String(10), index=True, nullable=False)
     medal = db.Column(db.ForeignKey(Medals.id))
     __tableargs__ = (db.PrimaryKeyConstraint(rodne_cislo, medal),)
+
+
+class DonorsOverview(db.Model):
+    __tablename__ = "donors_overview"
+    rodne_cislo = db.Column(db.String(10), primary_key=True)
+    first_name = db.Column(db.String, nullable=False)
+    last_name = db.Column(db.String, nullable=False)
+    address = db.Column(db.String, nullable=False)
+    city = db.Column(db.String, nullable=False)
+    postal_code = db.Column(db.String(5), nullable=False)
+    kod_pojistovny = db.Column(db.String(3), nullable=False)
+    donation_count_fm = db.Column(db.Integer, nullable=False)
+    donation_count_fm_bubenik = db.Column(db.Integer, nullable=False)
+    donation_count_trinec = db.Column(db.Integer, nullable=False)
+    donation_count_manual = db.Column(db.Integer, nullable=False)
+    donation_count_total = db.Column(db.Integer, nullable=False)
+    awarded_medal_br = db.Column(db.Boolean, nullable=False)
+    awarded_medal_st = db.Column(db.Boolean, nullable=False)
+    awarded_medal_zl = db.Column(db.Boolean, nullable=False)
+    awarded_medal_kr3 = db.Column(db.Boolean, nullable=False)
+    awarded_medal_kr2 = db.Column(db.Boolean, nullable=False)
+    awarded_medal_kr1 = db.Column(db.Boolean, nullable=False)
+
+    def __repr__(self):
+        return f"<DonorsOverview ({self.rodne_cislo})>"


### PR DESCRIPTION
Nová přehledová tabulka slouží zobrazení všech dárců společně s jejich počtem odběrů podle jednotlivých měst a se získanými medailemi. Jedná se pouze o „pohled“, její obsah se sestavuje z hodnot v ostatních tabulkách.

Samočinné naplnění je potřeba teprve napsat. Bude vyžadovat začlenění seznamů a vazeb z #9.