### PR TITLE
Naplň číselníky medailí a středisek

### DIFF
--- a/migrations/versions/7eeb86607ef1_fill_lists.py
+++ b/migrations/versions/7eeb86607ef1_fill_lists.py
@@ -1,0 +1,63 @@
+"""fill_lists
+
+Revision ID: 7eeb86607ef1
+Revises: 9d51ae0ab1e0
+Create Date: 2020-09-27 10:24:42.298975
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7eeb86607ef1"
+down_revision = "9d51ae0ab1e0"
+branch_labels = None
+depends_on = None
+
+donation_center = sa.table(
+    "donation_center", sa.column("slug", sa.String), sa.column("title", sa.String)
+)
+medals = sa.table("medals", sa.column("slug", sa.String), sa.column("title", sa.String))
+
+
+def upgrade():
+    op.execute(
+        donation_center.insert().values(
+            (
+                {
+                    donation_center.c.slug: "fm",
+                    donation_center.c.title: "Frýdek-Místek",
+                },
+                {
+                    donation_center.c.slug: "fm_bubenik",
+                    donation_center.c.title: "Frýdek-Místek, Krevní centrum",
+                },
+                {donation_center.c.slug: "trinec", donation_center.c.title: "Třinec"},
+            )
+        )
+    )
+    op.execute(
+        medals.insert().values(
+            (
+                {medals.c.slug: "br", medals.c.title: "Bronzová medaile"},
+                {medals.c.slug: "st", medals.c.title: "Stříbrná medaile"},
+                {medals.c.slug: "zl", medals.c.title: "Zlatá medaile"},
+                {medals.c.slug: "kr3", medals.c.title: "Zlatý kříž 3. třídy"},
+                {medals.c.slug: "kr2", medals.c.title: "Zlatý kříž 2. třídy"},
+                {medals.c.slug: "kr1", medals.c.title: "Zlatý kříž 1. třídy"},
+            )
+        )
+    )
+
+
+def downgrade():
+    op.execute(
+        donation_center.delete().where(
+            donation_center.c.slug.in_(("fm", "fm_bubenik", "trinec"))
+        )
+    )
+    op.execute(
+        medals.delete().where(
+            medals.c.slug.in_(("br", "st", "zl", "kr3", "kr2", "kr1"))
+        )
+    )


### PR DESCRIPTION
Krátké názvy vzety z původních názvů sloupců. Popisky spíše odhadnuty. Uprav si je dle potřeby. Mně přijde _bubenik_ jako dost pitomý název. Stejně tak mít jedno FM bezpříznakové a druhé s příznakem. Něco jako „fm_kdovíco“ a „fm-krevní_centrum“ bych viděl radši. Lepší zkrácené názvy by se pak měly projevit i v názvech sloupců souhrnné tabulky v #11.

Pozor, navazuje na #9 a zahrnuje změny z něj.