### PR TITLE
Add a new migration to merge two heads

### DIFF
--- a/migrations/versions/3f6d357b2be2_merge_of_multiple_heads.py
+++ b/migrations/versions/3f6d357b2be2_merge_of_multiple_heads.py
@@ -1,0 +1,23 @@
+"""merge of multiple heads
+
+Revision ID: 3f6d357b2be2
+Revises: 217337f9b133, 7eeb86607ef1
+Create Date: 2020-10-05 12:36:44.200356
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3f6d357b2be2"
+down_revision = ("217337f9b133", "7eeb86607ef1")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Jen prázdná migrace, která slučuje dvě předchozí "hlavy" do jedné navazující migrace. Zde je popis toho, co se vlastně stalo: https://blog.jerrycodes.com/multiple-heads-in-alembic-migrations/