### PR TITLE
Vkládej počet darování jako celé číslo

### DIFF
--- a/registry/commands.py
+++ b/registry/commands.py
@@ -74,7 +74,7 @@ def install_test_data():
                 city=city,
                 postal_code=postal_code,
                 kod_pojistovny=kod_pojistovny,
-                donation_count=donation_count,
+                donation_count=int(float(donation_count)) if donation_count else 0,
             )
             db.session.add(record)
 


### PR DESCRIPTION
Databázový sloupec donation_count je vedený jako celé číslo. SQLite se sice vypořádá s tím, když se do něj pokusíme vložit desetinné číslo v řetězci `"10.0"`, nebo prázdný řetězec `""`, ale jiné databázové systémy, jmenovitě PostgreSQL na tom vybouchnou.

Přidal jsem do příkazu zavádějícího pokusná data převod na celé číslo. Desetiny nepředpokládáme, `""` považujeme za nulu.