### PR TITLE
Stránka s detailem dárce

### DIFF
--- a/migrations/versions/149e19e8c994_create_initial_import_data_tables.py
+++ b/migrations/versions/149e19e8c994_create_initial_import_data_tables.py
@@ -27,15 +27,15 @@ def upgrade():
     op.create_table(
         "batches",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("donation_center", sa.Integer(), nullable=True),
+        sa.Column("donation_center_id", sa.Integer(), nullable=True),
         sa.Column("imported_at", sa.DateTime(), nullable=False),
-        sa.ForeignKeyConstraint(["donation_center"], ["donation_center.id"]),
+        sa.ForeignKeyConstraint(["donation_center_id"], ["donation_center.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
         "records",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("batch", sa.Integer(), nullable=False),
+        sa.Column("batch_id", sa.Integer(), nullable=False),
         sa.Column("rodne_cislo", sa.String(length=10), nullable=False),
         sa.Column("first_name", sa.String(), nullable=False),
         sa.Column("last_name", sa.String(), nullable=False),
@@ -44,7 +44,7 @@ def upgrade():
         sa.Column("postal_code", sa.String(length=5), nullable=False),
         sa.Column("kod_pojistovny", sa.String(length=3), nullable=False),
         sa.Column("donation_count", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["batch"], ["batches.id"]),
+        sa.ForeignKeyConstraint(["batch_id"], ["batches.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(

--- a/migrations/versions/9d51ae0ab1e0_create_medals_tables.py
+++ b/migrations/versions/9d51ae0ab1e0_create_medals_tables.py
@@ -27,12 +27,12 @@ def upgrade():
     op.create_table(
         "awarded_medals",
         sa.Column("rodne_cislo", sa.String(length=10), nullable=False),
-        sa.Column("medal", sa.Integer(), nullable=False),
+        sa.Column("medal_id", sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(
-            ["medal"],
+            ["medal_id"],
             ["medals.id"],
         ),
-        sa.PrimaryKeyConstraint("rodne_cislo", "medal"),
+        sa.PrimaryKeyConstraint("rodne_cislo", "medal_id"),
     )
     op.create_index(
         op.f("ix_awarded_medals_rodne_cislo"),

--- a/registry/donor/forms.py
+++ b/registry/donor/forms.py
@@ -2,7 +2,8 @@ from flask_wtf import FlaskForm
 from wtforms import SelectField, TextAreaField
 from wtforms.validators import DataRequired
 
-from .models import DonationCenter
+from registry.list.models import DonationCenter
+
 from .utils import validate_import_data
 
 

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -13,10 +13,11 @@ from flask import (
 from flask_login import login_required
 
 from registry.extensions import db
+from registry.list.models import DonationCenter
 from registry.utils import flash_errors
 
 from .forms import ImportForm
-from .models import Batch, DonorsOverview, Record
+from .models import AwardedMedals, Batch, DonorsOverview, Record
 
 blueprint = Blueprint("donor", __name__, static_folder="../static")
 
@@ -91,3 +92,19 @@ def overview_data():
     params = request.args.to_dict()
     row_table = DataTables(params, query, columns)
     return jsonify(row_table.output_result())
+
+
+@blueprint.route("/detail/<rc>", methods=("GET",))
+@login_required
+def detail(rc):
+    overview = DonorsOverview.query.get(rc)
+    records = Record.query.filter(Record.rodne_cislo == rc).all()
+    donation_centers = DonationCenter.query.all()
+    awarded_medals = AwardedMedals.query.filter(AwardedMedals.rodne_cislo == rc).all()
+    return render_template(
+        "donor/detail.html",
+        overview=overview,
+        donation_centers=donation_centers,
+        records=records,
+        awarded_medals=awarded_medals,
+    )

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -56,7 +56,7 @@ def import_data_post():
     import_form = ImportForm(request.form)
     if import_form.validate_on_submit():
         batch = Batch(
-            donation_center=import_form.donation_center.id,
+            donation_center_id=import_form.donation_center.id,
             imported_at=datetime.now(),
         )
         db.session.add(batch)

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -34,7 +34,7 @@
 
 <h2>Historie importů</h2>
 
-<table>
+<table id="records">
     <thead>
         <th>Dávka</th>
         <th>Importováno</th>
@@ -67,4 +67,16 @@
     </tbody>
 </table>
 
+{% endblock %}
+
+{% block js %}
+<script type="text/javascript">
+    $(document).ready( function () {
+        $('#records').DataTable({
+            language: {
+                url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Czech.json'
+            },
+        });
+    });
+</script>
 {% endblock %}

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -1,0 +1,70 @@
+{% extends "layout.html" %}
+{% block content %}
+
+<h1>Detail dárce</h1>
+
+<h2>Aktuální informace</h2>
+
+<ul>
+    <li>Rodné číslo: {{ overview.rodne_cislo }}</li>
+    <li>Jméno: {{ overview.first_name }}</li>
+    <li>Příjmení: {{ overview.last_name }}</li>
+    <li>Adresa: {{ overview.address }}</li>
+    <li>Město: {{ overview.city }}</li>
+    <li>PSČ: {{ overview.postal_code }}</li>
+    <li>Pojišťovna: {{ overview.kod_pojistovny }}</li>
+</ul>
+
+<h2>Počty darování</h2>
+
+<ul>
+    {% for donation_center in donation_centers %}
+        <li>{{ donation_center.title }}: {{ overview["donation_count_" + donation_center.slug] }}</li>
+    {% endfor %}
+    <li><b>Celkem: {{ overview.donation_count_total }}</b></li>
+</ul>
+
+<h2>Získaná ocenění</h2>
+
+<ul>
+    {% for awarded_medal in awarded_medals %}
+        <li>{{ awarded_medal.medal.title }}</li>
+    {% endfor %}
+</ul>
+
+<h2>Historie importů</h2>
+
+<table>
+    <thead>
+        <th>Dávka</th>
+        <th>Importováno</th>
+        <th>Centrum</th>
+        <th>Rodné číslo</th>
+        <th>Jméno</th>
+        <th>Příjmení</th>
+        <th>Adresa</th>
+        <th>Město</th>
+        <th>PSČ</th>
+        <th>Pojišťovna</th>
+        <th>Počet darování</th>
+    </thead>
+    <tbody>
+        {% for record in records %}
+        <tr>
+            <td>{{ record.batch_id }}</td>
+            <td>{{ record.batch.imported_at }}</td>
+            <td>{{ record.batch.donation_center.title }}</td>
+            <td>{{ record.rodne_cislo }}</td>
+            <td>{{ record.first_name }}</td>
+            <td>{{ record.last_name }}</td>
+            <td>{{ record.address }}</td>
+            <td>{{ record.city }}</td>
+            <td>{{ record.postal_code }}</td>
+            <td>{{ record.kod_pojistovny }}</td>
+            <td>{{ record.donation_count }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}

--- a/registry/templates/donor/overview.html
+++ b/registry/templates/donor/overview.html
@@ -58,6 +58,10 @@ Jinde: ${row.donation_count_manual}`;
                 null, // calculated column awards
             ],
             "columnDefs": [{
+                "targets": "rodne_cislo",
+                "render": function ( data, type, row, meta ) {
+                  return "<a href='"+"{{ url_for('donor.detail', rc='REPLACE_ME') }}".replace("REPLACE_ME", row.rodne_cislo) + "'>" + row.rodne_cislo + "</a>";}
+            },{
                 "targets": "donations",
                 "render": function ( data, type, row, meta ) {
                   return row.donation_count_total + create_tooltip_for_donations(row);}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -54,14 +54,14 @@ def test_data_records(db, limit=None):
 
             if import_date not in batches:
                 batches[import_date] = Batch(
-                    donation_center=donation_center_id,
+                    donation_center_id=donation_center_id,
                     imported_at=datetime.strptime(import_date, "%Y-%m-%d %H:%M:%S"),
                 )
                 db.session.add(batches[import_date])
                 db.session.commit()
 
             record = Record(
-                batch=batches[import_date].id,
+                batch_id=batches[import_date].id,
                 rodne_cislo=rodne_cislo,
                 first_name=first_name,
                 last_name=last_name,
@@ -82,7 +82,7 @@ def test_data_records(db, limit=None):
 
 
 def award_medal(db, rodne_cislo, medal_id):
-    awarded_medal = AwardedMedals(rodne_cislo=rodne_cislo, medal=medal_id)
+    awarded_medal = AwardedMedals(rodne_cislo=rodne_cislo, medal_id=medal_id)
     db.session.add(awarded_medal)
 
 


### PR DESCRIPTION
Závisí na #28 a #29 a vlastně tedy jde jen o poslední 4 commity.

Zjistil jsem, že v datech nemáme definované vztahy mezi modely a tak by se na sebe navazující informace musely tahat ručně. Například bych jako AwardedMedals dostal seznam medailí, které už daný dárce má, ale jejich názvy bych si pak musel ručně vytáhnout pomocí modelu Medals. To je nepraktické a tak jsem se rozhodl cizí klíče pojmenovat se suffixem `_id` a název bez tohoto suffixu využít jako odkaz na související model, kterým se vše podstatně zjednoduší. Například AwardedMedals tedy nově vypadá takto:

```
* rodne_cislo - sloupec s rodným číslem
* medal_id - sloupec s idečkem medaile, cizí klíč
* medal - odkaz na medaili samotnou, který dále obsahuje její atributy a tedy
  * id - idečko, stejné jako medal_id
  * slug - krátké označení
  * title - plný název
```

A pak jsem narazi na problém. SQLite totiž neumí přejmenovat sloupce. Resp. ono to jde, ale musí se to udělat v dávkovém režimu. V dávkovém režimu pak ale zase neumí pracovat s nepojmenovanými constraints jako jsou třeba cizí klíče. Po nějakém čase jsem se tedy rozhodl raději sloupce přejmenovat v historii migrací. To je samozřejmě špatně a nikdy by se to nemělo dělat, ale ještě nefungujeme v produkci a já už nemám více energie pro práci na kombinaci SQLite, Alembic a SQLAlchemy. Pro vás to znamená, že až tohle sloučíme, budete si muset smazat a znovu vytvořit databázi. Kdybychom běželi na produkci, tak by to nešlo, resp. by nasazení nové verze vyžadovalo ruční a ne zrovna jednoduchý zásah a bylo by to celkově dost nepříjemné.

S touto změnou pak už byla celkem hračka vytvořit přehledovou stránku a bez složitých dotazů moci tahat věci jako `record.batch.donation_center.title` pěkně v jednom kroku.