### PR TITLE
Importuj pandas jen pokud je opravdu potřeba

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,6 @@ from datetime import datetime
 from functools import lru_cache
 from random import uniform
 
-import pandas
-
 from registry.donor.models import AwardedMedals, Batch, Record
 from registry.list.models import DonationCenter, Medals
 
@@ -132,6 +130,8 @@ def test_data_medals(db):
 @lru_cache()
 def get_test_data_df(lines):
     """Returns test data from imports.csv as Pandas DataFrame"""
+    import pandas  # noqa
+
     return pandas.read_csv(
         "tests/data/imports.csv", dtype={"RC": str, "PSC": str, "POJISTOVNA": str}
     ).head(lines)


### PR DESCRIPTION
Kvůli kaskádě importů od modulu app přes command až po testovací utility se jinak importuje pandas při každém spuštění, což nefunguje v produkci.