### PR TITLE
Přidej Python 3.10 do testů

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         dnf_install: pkgconfig(libffi)
     strategy:
       matrix:
-        tox_env: [py36, py37, py38, py39, lint]
+        tox_env: [py36, py37, py38, py39, py310, lint]
 
     # Use GitHub's Linux Docker host
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py{36,37,38,39}
+envlist = lint,py{36,37,38,39,310}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Aktuálně nefunguje, protože některé balíky nemají wheely a třeba greenlet ani nejde zkompilovat.

Otevřeno jen aby se nezapommělo.