### PR TITLE
Přepisování údajů dárce

### DIFF
--- a/migrations/versions/60a681c463a2_create_donors_override.py
+++ b/migrations/versions/60a681c463a2_create_donors_override.py
@@ -1,7 +1,7 @@
 """create_donors_override
 
 Revision ID: 60a681c463a2
-Revises: 6fe71f4f1aba
+Revises: 971ddb205e0c
 Create Date: 2021-05-25 12:50:58.779359
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "60a681c463a2"
-down_revision = "6fe71f4f1aba"
+down_revision = "971ddb205e0c"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/60a681c463a2_create_donors_override.py
+++ b/migrations/versions/60a681c463a2_create_donors_override.py
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "60a681c463a2"
-down_revision = "971ddb205e0c"
+down_revision = "467ee396a68e"
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/60a681c463a2_create_donors_override.py
+++ b/migrations/versions/60a681c463a2_create_donors_override.py
@@ -1,7 +1,7 @@
 """create_donors_override
 
 Revision ID: 60a681c463a2
-Revises: 971ddb205e0c
+Revises: 467ee396a68e
 Create Date: 2021-05-25 12:50:58.779359
 
 """

--- a/migrations/versions/60a681c463a2_create_donors_override.py
+++ b/migrations/versions/60a681c463a2_create_donors_override.py
@@ -1,0 +1,33 @@
+"""create_donors_override
+
+Revision ID: 60a681c463a2
+Revises: 6fe71f4f1aba
+Create Date: 2021-05-25 12:50:58.779359
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "60a681c463a2"
+down_revision = "6fe71f4f1aba"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "donors_override",
+        sa.Column("rodne_cislo", sa.CHAR(length=10), nullable=False),
+        sa.Column("first_name", sa.String(), nullable=True),
+        sa.Column("last_name", sa.String(), nullable=True),
+        sa.Column("address", sa.String(), nullable=True),
+        sa.Column("city", sa.String(), nullable=True),
+        sa.Column("postal_code", sa.CHAR(length=5), nullable=True),
+        sa.Column("kod_pojistovny", sa.CHAR(length=3), nullable=True),
+        sa.PrimaryKeyConstraint("rodne_cislo"),
+    )
+
+
+def downgrade():
+    op.drop_table("donors_override")

--- a/registry/donor/forms.py
+++ b/registry/donor/forms.py
@@ -49,12 +49,6 @@ class RemoveFromIgnoredForm(FlaskForm):
 
 
 class DonorsOverrideForm(FlaskForm):
-    class Meta:
-        def render_field(self, field, render_kw):
-            # Set the HTML "form" parameter for each of the fields
-            render_kw["form"] = "donorsOverrideForm"
-            return field.widget(field, **render_kw)
-
     rodne_cislo = StringField("Rodné číslo", validators=[DataRequired()])
     first_name = StringField("Jméno")
     last_name = StringField("Příjmení")
@@ -124,7 +118,3 @@ class DonorsOverrideForm(FlaskForm):
                 self.field_data[field] = data
             else:
                 self.field_data[field] = None
-
-
-class DonorsOverrideDeleteForm(FlaskForm):
-    rodne_cislo = HiddenField(validators=[DataRequired()])

--- a/registry/donor/forms.py
+++ b/registry/donor/forms.py
@@ -3,6 +3,7 @@ from wtforms import BooleanField, HiddenField, StringField, TextAreaField
 from wtforms.validators import DataRequired
 
 from registry.donor.models import AwardedMedals, DonorsOverride
+from registry.utils import NumericValidator
 
 
 class RemoveMedalForm(FlaskForm):
@@ -54,8 +55,8 @@ class DonorsOverrideForm(FlaskForm):
     last_name = StringField("Příjmení")
     address = StringField("Adresa")
     city = StringField("Město")
-    postal_code = StringField("PSČ")
-    kod_pojistovny = StringField("Pojišťovna")
+    postal_code = StringField("PSČ", validators=[NumericValidator(5)])
+    kod_pojistovny = StringField("Pojišťovna", validators=[NumericValidator(3)])
 
     _fields_ = [
         "rodne_cislo",
@@ -72,30 +73,8 @@ class DonorsOverrideForm(FlaskForm):
         if not initial_validation:
             return False
 
-        valid = True
-
-        if self.postal_code.data:
-            self.postal_code.data = self.postal_code.data.replace(" ", "")
-            if not self.postal_code.data.isdigit():
-                self.postal_code.errors.append(
-                    "PSČ může obsahovat pouze číslice a mezeru"
-                )
-                valid = False
-            if len(self.postal_code.data) != 5:
-                self.postal_code.errors.append("PSČ musí mít 5 znaků kromě mezer")
-                valid = False
-
-        if self.kod_pojistovny.data:
-            if not self.kod_pojistovny.data.isdigit():
-                self.kod_pojistovny.errors.append("Kód pojišťovny musí být číslo")
-                valid = False
-            if len(self.kod_pojistovny.data) != 3:
-                self.kod_pojistovny.errors.append("Kód pojišťovny musí být třímístný")
-                valid = False
-
         self._get_field_data()
-
-        return valid
+        return True
 
     def init_fields(self, rodne_cislo):
         override = DonorsOverride.query.get(rodne_cislo)

--- a/registry/donor/forms.py
+++ b/registry/donor/forms.py
@@ -49,6 +49,12 @@ class RemoveFromIgnoredForm(FlaskForm):
 
 
 class DonorsOverrideForm(FlaskForm):
+    class Meta:
+        def render_field(self, field, render_kw):
+            # Set the HTML "form" parameter for each of the fields
+            render_kw["form"] = "donorsOverrideForm"
+            return field.widget(field, **render_kw)
+
     rodne_cislo = StringField("Rodné číslo", validators=[DataRequired()])
     first_name = StringField("Jméno")
     last_name = StringField("Příjmení")
@@ -118,3 +124,7 @@ class DonorsOverrideForm(FlaskForm):
                 self.field_data[field] = data
             else:
                 self.field_data[field] = None
+
+
+class DonorsOverrideDeleteForm(FlaskForm):
+    rodne_cislo = HiddenField(validators=[DataRequired()])

--- a/registry/donor/forms.py
+++ b/registry/donor/forms.py
@@ -68,14 +68,6 @@ class DonorsOverrideForm(FlaskForm):
         "kod_pojistovny",
     ]
 
-    def validate(self):
-        initial_validation = super(DonorsOverrideForm, self).validate()
-        if not initial_validation:
-            return False
-
-        self._get_field_data()
-        return True
-
     def init_fields(self, rodne_cislo):
         override = DonorsOverride.query.get(rodne_cislo)
 
@@ -87,13 +79,9 @@ class DonorsOverrideForm(FlaskForm):
 
         self.rodne_cislo.data = rodne_cislo
 
-        return self
-
-    def _get_field_data(self):
-        self.field_data = {}
+    def get_field_data(self):
+        field_data = {}
         for field in self._fields_:
-            data = getattr(self, field).data
-            if data:
-                self.field_data[field] = data
-            else:
-                self.field_data[field] = None
+            field_data[field] = getattr(self, field).data or None
+
+        return field_data

--- a/registry/donor/forms.py
+++ b/registry/donor/forms.py
@@ -114,5 +114,7 @@ class DonorsOverrideForm(FlaskForm):
         self.field_data = {}
         for field in self._fields_:
             data = getattr(self, field).data
-            if data != "":
+            if data:
                 self.field_data[field] = data
+            else:
+                self.field_data[field] = None

--- a/registry/donor/models.py
+++ b/registry/donor/models.py
@@ -445,3 +445,14 @@ class Note(db.Model):
     __tablename__ = "notes"
     rodne_cislo = db.Column(db.String(10), primary_key=True)
     note = db.Column(db.Text)
+
+
+class DonorsOverride(db.Model):
+    __tablename__ = "donors_override"
+    rodne_cislo = db.Column(db.String(10), primary_key=True)
+    first_name = db.Column(db.String)
+    last_name = db.Column(db.String)
+    address = db.Column(db.String)
+    city = db.Column(db.String)
+    postal_code = db.Column(db.String(5))
+    kod_pojistovny = db.Column(db.String(3))

--- a/registry/donor/models.py
+++ b/registry/donor/models.py
@@ -189,7 +189,7 @@ WHERE "rodne_cislo" IN (SELECT "rodne_cislo" FROM "ignored_donors");
         return donor_dict
 
     def refresh_override(cls, commit=True):
-        if sqlite3.sqlite_version_info[0] >= 3 and sqlite3.sqlite_version_info[1] >= 33:
+        if sqlite3.sqlite_version_info >= (3, 33):
             # The UPDATE - FROM syntax is supported from SQLite version 3.33.0
             db.session.execute(
                 """

--- a/registry/donor/models.py
+++ b/registry/donor/models.py
@@ -564,3 +564,21 @@ class DonorsOverride(db.Model):
     city = db.Column(db.String)
     postal_code = db.Column(db.String(5))
     kod_pojistovny = db.Column(db.String(3))
+
+    def to_dict(self):
+        result = {}
+        for field in [
+            "rodne_cislo",
+            "first_name",
+            "last_name",
+            "address",
+            "city",
+            "postal_code",
+            "kod_pojistovny",
+        ]:
+            if getattr(self, field) is not None:
+                result[field] = str(getattr(self, field))
+            else:
+                result[field] = None
+
+        return result

--- a/registry/donor/models.py
+++ b/registry/donor/models.py
@@ -188,6 +188,7 @@ WHERE "rodne_cislo" IN (SELECT "rodne_cislo" FROM "ignored_donors");
         donor_dict["donations"]["total"] = self.donation_count_total
         return donor_dict
 
+    @classmethod
     def refresh_override(cls, commit=True):
         if sqlite3.sqlite_version_info >= (3, 33):
             # The UPDATE - FROM syntax is supported from SQLite version 3.33.0

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -287,7 +287,7 @@ def save_override():
     if override_form.validate_on_submit():
         if not delete:
             override = DonorsOverride(**override_form.field_data)
-            db.session.add(override)
+            db.session.merge(override)
             db.session.commit()
 
             DonorsOverview.refresh_overview()

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -35,7 +35,6 @@ from .models import (
     Record,
 )
 
-
 blueprint = Blueprint("donor", __name__, static_folder="../static")
 
 

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -278,7 +278,7 @@ def unignore_donor():
     return redirect(url_for("donor.show_ignored"))
 
 
-@blueprint.post("/override")
+@blueprint.post("/override/")
 @login_required
 def save_override():
     override_form = DonorsOverrideForm()
@@ -306,3 +306,14 @@ def save_override():
         flash_errors(override_form)
 
     return redirect(url_for("donor.detail", rc=override_form.rodne_cislo.data))
+
+
+@blueprint.get("/override/all")
+@login_required
+def get_overrides():
+    overrides_dict = {}
+
+    for override in DonorsOverride.query.all():
+        overrides_dict[str(override.rodne_cislo)] = override.to_dict()
+
+    return jsonify(overrides_dict)

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -289,12 +289,16 @@ def save_override():
             override = DonorsOverride(**override_form.field_data)
             db.session.add(override)
             db.session.commit()
+
+            DonorsOverview.refresh_overview()
             flash("Výjimka uložena", "success")
         else:
             override = DonorsOverride.query.get(override_form.rodne_cislo.data)
             if override is not None:
                 db.session.delete(override)
                 db.session.commit()
+
+                DonorsOverview.refresh_overview()
                 flash("Výjimka smazána", "success")
             else:
                 flash("Není co mazat", "warning")

--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -114,7 +114,8 @@ def detail(rc):
     note_form = NoteForm()
     if overview.note:
         note_form.note.data = overview.note.note
-    donors_override_form = DonorsOverrideForm().init_fields(rc)
+    donors_override_form = DonorsOverrideForm()
+    donors_override_form.init_fields(rc)
 
     return render_template(
         "donor/detail.html",
@@ -286,7 +287,7 @@ def save_override():
     if form.validate_on_submit():
         if not delete:
             # Save the override
-            override = DonorsOverride(**form.field_data)
+            override = DonorsOverride(**form.get_field_data())
             db.session.merge(override)
             db.session.commit()
 
@@ -315,6 +316,6 @@ def get_overrides():
     overrides_dict = {}
 
     for override in DonorsOverride.query.all():
-        overrides_dict[str(override.rodne_cislo)] = override.to_dict()
+        overrides_dict[override.rodne_cislo] = override.to_dict()
 
     return jsonify(overrides_dict)

--- a/registry/static/donors_override_highlight.js
+++ b/registry/static/donors_override_highlight.js
@@ -1,0 +1,39 @@
+/**
+ * Sets up highlighting of values overriden in donors_override
+ * @param {string} url The URL to request (url_for('donor.get_overrides'))
+ * @param {object} columnDefs DataTables columnDefs
+ * @param {Function} onDataReady Called when information about overrides is downloaded
+ */
+function highlightOverridenValues(url, columnDefs, onDataReady) {
+    let overrides = {}; // Will be set by an AJAX request
+
+    for (const column of ["first_name", "last_name", "address", "city", "postal_code", "kod_pojistovny"]) {
+        columnDefs.push({
+            "targets": column,
+            "name": column,
+            "render": function (data, type, row, meta) {
+                // We only want to highlight the value that is displayed
+                // to the user, not the ones used for searching and sorting
+                if (type != "display") return data;
+                
+                let rodneCislo;
+                if (row instanceof Array)
+                    rodneCislo = row[0]
+                else
+                    rodneCislo = row.rodne_cislo;
+
+                if (overrides.hasOwnProperty(rodneCislo) && overrides[rodneCislo][column]) {
+                    return `<mark title="Tato hodnota byla ručně nastavena">${data}</mark>`;
+                } else {
+                    return data;
+                }
+            }
+        });
+    }
+
+    // Request the list of overrides
+    $.getJSON(url, function (data) {
+        overrides = data;
+        onDataReady && onDataReady();
+    });
+}

--- a/registry/templates/donor/award_prep.html
+++ b/registry/templates/donor/award_prep.html
@@ -50,14 +50,6 @@
 
 {% endblock %}
 
-{% block css %}
-<style>
-    mark {
-        background-color: #f7ebb1;
-    }
-</style>
-{% endblock %}
-
 {% block js %}
 <script src="/static/donors_override_highlight.js"></script>
 <script type="text/javascript">

--- a/registry/templates/donor/award_prep.html
+++ b/registry/templates/donor/award_prep.html
@@ -14,13 +14,13 @@
 <table id="overview" class="table table-striped table-hovered table-hover">
     <thead class="thead-dark">
         <tr>
-            <th class="rodne_cislo">Rodné číslo</th>
-            <th>Jméno</th>
-            <th>Přijmení</th>
-            <th>Adresa</th>
-            <th>Město</th>
-            <th>PSČ</th>
-            <th>Pojišťovna</th>
+            <th class="rodne_cislo" data-name="rodne-cislo">Rodné číslo</th>
+            <th class="first_name">Jméno</th>
+            <th class="last_name">Přijmení</th>
+            <th class="address">Adresa</th>
+            <th class="city">Město</th>
+            <th class="postal_code">PSČ</th>
+            <th class="kod_pojistovny">Pojišťovna</th>
             <th>Darování</th>
             <th class="sign">Podpis</th>
             <th class="chosen">Vybrat vše <input type="checkbox" onClick="toggle(this)" checked=true></th>
@@ -51,33 +51,42 @@
 {% endblock %}
 
 {% block js %}
+<script src="/static/donors_override_highlight.js"></script>
 <script type="text/javascript">
     $(document).ready( function () {
-        $('#overview').DataTable({
-            language: {
-                url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Czech.json'
-            },
-            buttons: [{
-                extend: 'print',
-                text: 'Tisk prezenční listiny',
-                title: '',
-                exportOptions: {
-                    columns: [...Array(9).keys()]
-                }
-            }],
-            dom: "Blfrtip",
-            columnDefs: [{
+        const columnDefs =  [{
                 "targets": "rodne_cislo",
-                "render": function ( data, type, row, meta ) {
-                  return "<a href='"+"{{ url_for('donor.detail', rc='REPLACE_ME') }}".replace("REPLACE_ME", row[0]) + "'>" + row[0] + "</a>";}
-            },{
+                "render": function (data, type, row, meta) {
+                    if (type == "display")
+                        return "<a href='"+"{{ url_for('donor.detail', rc='REPLACE_ME') }}".replace("REPLACE_ME", row[0]) + "'>" + row[0] + "</a>"
+                    else
+                        return data;
+                }
+            }, {
                 "targets": "sign",
                 "visible": false
-            },{
+            }, {
                 "targets": "chosen",
                 "orderable": false
-            }]
-        });
+            }];
+
+        highlightOverridenValues("{{ url_for('donor.get_overrides') }}", columnDefs, function() {
+            $('#overview').DataTable({
+                language: {
+                    url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Czech.json'
+                },
+                buttons: [{
+                    extend: 'print',
+                    text: 'Tisk prezenční listiny',
+                    title: '',
+                    exportOptions: {
+                        columns: [...Array(9).keys()]
+                    }
+                }],
+                dom: "Blfrtip",
+                columnDefs: columnDefs
+            });
+        });        
     } );
 
     function toggle(source) {

--- a/registry/templates/donor/award_prep.html
+++ b/registry/templates/donor/award_prep.html
@@ -50,6 +50,14 @@
 
 {% endblock %}
 
+{% block css %}
+<style>
+    mark {
+        background-color: #f7ebb1;
+    }
+</style>
+{% endblock %}
+
 {% block js %}
 <script src="/static/donors_override_highlight.js"></script>
 <script type="text/javascript">

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -150,6 +150,37 @@
 
 </div>
 
+<h2>Přepsání údajů</h2>
+{% with form=donors_override_form %}
+<form id="donorsOverrideForm" action="{{ url_for('donor.save_override') }}" method="POST">
+    {{ form.csrf_token }}
+    <table class="table table-striped table-hovered table-hover">
+        <thead class="thead-dark">
+            <th>Rodné číslo</th>
+            <th>Jméno</th>
+            <th>Příjmení</th>
+            <th>Adresa</th>
+            <th>Město</th>
+            <th>PSČ</th>
+            <th>Pojišťovna</th>
+            <th></th>
+        </thead>
+        <tbody>
+            <td>{{ form.rodne_cislo(readonly=True, size=8, class_="form-control") }}</td>
+            <td>{{ form.first_name(size=8, class_="form-control") }}</td>
+            <td>{{ form.last_name(size=8, class_="form-control") }}</td>
+            <td>{{ form.address(size=10, class_="form-control") }}</td>
+            <td>{{ form.city(size=8, class_="form-control") }}</td>
+            <td>{{ form.postal_code(size=3, class_="form-control") }}</td>
+            <td>{{ form.kod_pojistovny(size=3, class_="form-control") }}</td>
+            <td>
+                <button name="save_btn" class="btn btn-success" type="submit" title="Uložit výjimku">✔</button>
+                <button name="delete_btn" class="btn btn-danger" type="submit" title="Smazat výjimku">🗑</button>
+            </td>
+        </tbody>
+    </table>
+</form>
+{% endwith %}
 
 <h2>Historie importů</h2>
 

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -1,4 +1,42 @@
 {% extends "layout.html" %}
+{% block css %}
+<style>
+    #override_forms {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    #override_forms div {
+        background-color: #0000000d;
+        flex-grow: 1;
+        margin-top: 12px;
+    }
+
+    #override_forms label {
+        color: white;
+        background-color: #343a40;
+        font-weight: bold;
+        width: 100%;
+        margin: 0;
+        padding: 12px;
+    }
+
+    #override_forms input {
+        margin: 6px;
+        width: calc(100% - 12px);
+    }
+
+    #override_forms .btn_container {
+        flex-grow: unset;
+    }
+    #override_forms .btn_container label {
+        padding: 12px 0;
+    }
+    #override_forms .btn_container button {
+        margin: 6px 0;
+    }
+</style>
+{% endblock %}
 {% block content %}
 
 
@@ -152,35 +190,58 @@
 
 <h2>Přepsání údajů</h2>
 {% with form=donors_override_form %}
-<form id="donorsOverrideForm" action="{{ url_for('donor.save_override') }}" method="POST">
-    {{ form.csrf_token }}
-    <table class="table table-striped table-hovered">
-        <thead class="thead-dark">
-            <th>Rodné číslo</th>
-            <th>Jméno</th>
-            <th>Příjmení</th>
-            <th>Adresa</th>
-            <th>Město</th>
-            <th>PSČ</th>
-            <th>Pojišťovna</th>
-            <th></th>
-        </thead>
-        <tbody>
-            <td>{{ form.rodne_cislo(readonly=True, size=8, class_="form-control") }}</td>
-            <td>{{ form.first_name(size=8, class_="form-control") }}</td>
-            <td>{{ form.last_name(size=8, class_="form-control") }}</td>
-            <td>{{ form.address(size=10, class_="form-control") }}</td>
-            <td>{{ form.city(size=8, class_="form-control") }}</td>
-            <td>{{ form.postal_code(size=3, class_="form-control") }}</td>
-            <td>{{ form.kod_pojistovny(size=3, class_="form-control") }}</td>
-            <td>
-                <button name="save_btn" class="btn btn-success" type="submit" title="Uložit výjimku">✔</button>
-                <button name="delete_btn" class="btn btn-danger" type="submit" title="Smazat výjimku">🗑</button>
-            </td>
-        </tbody>
-    </table>
-</form>
+<div id="override_forms">
+    <div style="flex-grow: 8;">
+        <label for="rodne_cislo">Rodné číslo</label>
+        {{ form.rodne_cislo(readonly=True, size=8, class_="form-control") }}
+    </div>
+    <div style="flex-grow: 8;">
+        <label for="first_name">Jméno</label>
+        {{ form.first_name(size=8, class_="form-control") }}
+    </div>
+    <div style="flex-grow: 8;">
+        <label for="last_name">Příjmení</label>
+        {{ form.last_name(size=8, class_="form-control") }}
+    </div>
+    <div style="flex-grow: 10;">
+        <label for="address">Adresa</label>
+        {{ form.address(size=10, class_="form-control") }}
+    </div>
+    <div style="flex-grow: 8;">
+        <label for="city">Město</label>
+        {{ form.city(size=8, class_="form-control") }}
+    </div>
+    <div style="flex-grow: 3;">
+        <label for="postal_code">PSČ</label>
+        {{ form.postal_code(size=3, class_="form-control") }}
+    </div>
+    <div style="flex-grow: 3;">
+        <label for="kod_pojistovny">Pojišťovna</label>
+        {{ form.kod_pojistovny(size=3, class_="form-control") }}
+    </div>
+
+    <div class="btn_container">
+        <form id="donorsOverrideForm" action="{{ url_for('donor.save_override') }}" method="POST">
+            <label>&nbsp;</label>
+
+            {{ form.csrf_token }}
+            <button class="btn btn-success" type="submit" title="Uložit výjimku">✔</button>
+        </form>
+    </div>
 {% endwith %}
+{% with form=donors_override_delete_form %}
+    <div class="btn_container">
+        <form id="donorsOverrideDeleteForm" action="{{ url_for('donor.delete_override') }}" method="POST">
+            <label>&nbsp;</label>
+
+            {{ form.csrf_token }}
+            {{ form.rodne_cislo(value=overview.rodne_cislo) }}
+            <button class="btn btn-danger" type="submit" title="Smazat výjimku">🗑</button>
+        </form>
+    </div>
+{% endwith %}
+</div>
+
 
 <h2>Historie importů</h2>
 

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -1,18 +1,18 @@
 {% extends "layout.html" %}
 {% block css %}
 <style>
-    #override_forms {
+    #donorsOverrideForm {
         display: flex;
         flex-wrap: wrap;
     }
 
-    #override_forms div {
+    #donorsOverrideForm div {
         background-color: #0000000d;
         flex-grow: 1;
         margin-top: 12px;
     }
 
-    #override_forms label {
+    #donorsOverrideForm label {
         color: white;
         background-color: #343a40;
         font-weight: bold;
@@ -21,18 +21,18 @@
         padding: 12px;
     }
 
-    #override_forms input {
+    #donorsOverrideForm input {
         margin: 6px;
         width: calc(100% - 12px);
     }
 
-    #override_forms .btn_container {
+    #donorsOverrideForm .btn_container {
         flex-grow: unset;
     }
-    #override_forms .btn_container label {
+    #donorsOverrideForm .btn_container label {
         padding: 12px 0;
     }
-    #override_forms .btn_container button {
+    #donorsOverrideForm .btn_container button {
         margin: 6px 0;
     }
 </style>
@@ -190,7 +190,8 @@
 
 <h2>Přepsání údajů</h2>
 {% with form=donors_override_form %}
-<div id="override_forms">
+<form id="donorsOverrideForm" action="/override/" method="POST">
+    {{ form.csrf_token }}
     <div style="flex-grow: 8;">
         <label for="rodne_cislo">Rodné číslo</label>
         {{ form.rodne_cislo(readonly=True, size=8, class_="form-control") }}
@@ -221,26 +222,16 @@
     </div>
 
     <div class="btn_container">
-        <form id="donorsOverrideForm" action="{{ url_for('donor.save_override') }}" method="POST">
-            <label>&nbsp;</label>
-
-            {{ form.csrf_token }}
-            <button class="btn btn-success" type="submit" title="Uložit výjimku">✔</button>
-        </form>
+        <label>&nbsp;</label>
+        <button class="btn btn-success" type="submit" name="save_btn" title="Uložit výjimku">✔</button>
     </div>
-{% endwith %}
-{% with form=donors_override_delete_form %}
+
     <div class="btn_container">
-        <form id="donorsOverrideDeleteForm" action="{{ url_for('donor.delete_override') }}" method="POST">
-            <label>&nbsp;</label>
-
-            {{ form.csrf_token }}
-            {{ form.rodne_cislo(value=overview.rodne_cislo) }}
-            <button class="btn btn-danger" type="submit" title="Smazat výjimku">🗑</button>
-        </form>
+        <label>&nbsp;</label>
+        <button class="btn btn-danger" type="submit" name="delete_btn" title="Smazat výjimku">🗑</button>
     </div>
+</form>
 {% endwith %}
-</div>
 
 
 <h2>Historie importů</h2>

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -154,7 +154,7 @@
 {% with form=donors_override_form %}
 <form id="donorsOverrideForm" action="{{ url_for('donor.save_override') }}" method="POST">
     {{ form.csrf_token }}
-    <table class="table table-striped table-hovered table-hover">
+    <table class="table table-striped table-hovered">
         <thead class="thead-dark">
             <th>Rodné číslo</th>
             <th>Jméno</th>

--- a/registry/templates/donor/overview.html
+++ b/registry/templates/donor/overview.html
@@ -18,6 +18,14 @@
 
 {% endblock %}
 
+{% block css %}
+<style>
+    mark {
+        background-color: #f7ebb1;
+    }
+</style>
+{% endblock %}
+
 {% block js %}
 <script src="/static/donors_override_highlight.js"></script>
 <script type="text/javascript">

--- a/registry/templates/donor/overview.html
+++ b/registry/templates/donor/overview.html
@@ -29,7 +29,54 @@
     }
 
     $(document).ready( function () {
-        $('#overview').DataTable({
+        const columnDefs = [
+            {
+                "targets": "rodne_cislo",
+                "render": function (data, type, row, meta) {
+                    if (type == "display")
+                        return "<a href='"+"{{ url_for('donor.detail', rc='REPLACE_ME') }}".replace("REPLACE_ME", row.rodne_cislo) + "'>" + row.rodne_cislo + "</a>"
+                    else
+                        return data;
+                }
+            }, {
+                "targets": "donations",
+                "render": function (data, type, row, meta) {
+                    return data.total + create_tooltip_for_donations(data);
+                }
+            },
+        ];
+
+        // Highlight fields that have a corresponding record in donors_override
+        let overrides = {}; // Will be set by an AJAX request
+
+        for (const column of ["first_name", "last_name", "address", "city", "postal_code", "kod_pojistovny"]) {
+            columnDefs.push({
+                "targets": column,
+                "render": function (data, type, row, meta) {
+                    // We only want to highlight the value that is displayed
+                    // to the user, not the ones used for searching and sorting
+                    if (type != "display") return data;
+
+                    if (overrides.hasOwnProperty(row.rodne_cislo) && overrides[row.rodne_cislo][column]) {
+                        return `<mark title="Tato hodnota byla ručně nastavena">${data}</mark>`;
+                    } else {
+                        return data;
+                    }
+                }
+            });
+        }
+
+        // Forward declaration of the DataTable
+        let dataTable = null;
+
+        // Request the list of overrides
+        $.getJSON("{{ url_for('donor.get_overrides') }}", function (data) {
+            overrides = data;
+            if (dataTable !== null)
+                dataTable.draw();
+        });
+
+        dataTable = $('#overview').DataTable({
             language: {
                 url: '//cdn.datatables.net/plug-ins/1.10.21/i18n/Czech.json'
             },
@@ -41,15 +88,7 @@
                     {"data": "{{ column_class }}"},
                 {%- endfor %}
             ],
-            "columnDefs": [{
-                "targets": "rodne_cislo",
-                "render": function ( data, type, row, meta ) {
-                  return "<a href='"+"{{ url_for('donor.detail', rc='REPLACE_ME') }}".replace("REPLACE_ME", row.rodne_cislo) + "'>" + row.rodne_cislo + "</a>";}
-            },{
-                "targets": "donations",
-                "render": function ( data, type, row, meta ) {
-                  return data.total + create_tooltip_for_donations(data);}
-            },]
+            "columnDefs": columnDefs
         });
     } );
 </script>

--- a/registry/templates/donor/overview.html
+++ b/registry/templates/donor/overview.html
@@ -18,14 +18,6 @@
 
 {% endblock %}
 
-{% block css %}
-<style>
-    mark {
-        background-color: #f7ebb1;
-    }
-</style>
-{% endblock %}
-
 {% block js %}
 <script src="/static/donors_override_highlight.js"></script>
 <script type="text/javascript">

--- a/registry/templates/donor/overview.html
+++ b/registry/templates/donor/overview.html
@@ -19,6 +19,7 @@
 {% endblock %}
 
 {% block js %}
+<script src="/static/donors_override_highlight.js"></script>
 <script type="text/javascript">
     function create_tooltip_for_donations(data) {
         var title = ``;
@@ -46,32 +47,9 @@
             },
         ];
 
-        // Highlight fields that have a corresponding record in donors_override
-        let overrides = {}; // Will be set by an AJAX request
-
-        for (const column of ["first_name", "last_name", "address", "city", "postal_code", "kod_pojistovny"]) {
-            columnDefs.push({
-                "targets": column,
-                "render": function (data, type, row, meta) {
-                    // We only want to highlight the value that is displayed
-                    // to the user, not the ones used for searching and sorting
-                    if (type != "display") return data;
-
-                    if (overrides.hasOwnProperty(row.rodne_cislo) && overrides[row.rodne_cislo][column]) {
-                        return `<mark title="Tato hodnota byla ručně nastavena">${data}</mark>`;
-                    } else {
-                        return data;
-                    }
-                }
-            });
-        }
-
-        // Forward declaration of the DataTable
         let dataTable = null;
-
-        // Request the list of overrides
-        $.getJSON("{{ url_for('donor.get_overrides') }}", function (data) {
-            overrides = data;
+        
+        highlightOverridenValues("{{ url_for('donor.get_overrides') }}", columnDefs, function() {
             if (dataTable !== null)
                 dataTable.draw();
         });

--- a/registry/templates/layout.html
+++ b/registry/templates/layout.html
@@ -15,6 +15,13 @@
       Evidence dárců ČČK Frýdek-Místek
       {% endblock %}
     </title>
+
+    <style>
+      mark {
+        background-color: #f7ebb1;
+      }
+    </style>
+
     {% block css %}{% endblock %}
   </head>
   <body>

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -1,4 +1,3 @@
-import re
 from random import randint
 
 import pytest
@@ -96,8 +95,7 @@ class TestOverride:
         login(user, testapp)
         res = testapp.get(url_for("donor.detail", rc=rodne_cislo))
 
-        old_first_name = re.search(r"<li>\s*Jméno: (.*)\s*</li>", str(res)).group(1)
-        old_last_name = re.search(r"<li>\s*Příjmení: (.*)\s*</li>", str(res)).group(1)
+        old_data = DonorsOverview.query.get(rodne_cislo)
 
         # Test save
         form = res.forms["donorsOverrideForm"]
@@ -123,7 +121,7 @@ class TestOverride:
         res = form.submit("save_btn").follow()
 
         assert "Výjimka uložena" in res
-        assert ("Jméno: " + old_first_name) in res
+        assert ("Jméno: " + str(old_data.first_name)) in res
         assert "Příjmení: --Last--" in res
 
         # Test deleting the override
@@ -131,5 +129,5 @@ class TestOverride:
         res = form.submit("delete_btn").follow()
 
         assert "Výjimka smazána" in res
-        assert ("Jméno: " + old_first_name) in res
-        assert ("Příjmení: " + old_last_name) in res
+        assert ("Jméno: " + str(old_data.first_name)) in res
+        assert ("Příjmení: " + str(old_data.last_name)) in res

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -87,3 +87,48 @@ class TestIgnore:
 
         do = testapp.get(url_for("donor.detail", rc=rodne_cislo), status=200)
         assert do.status_code == 200
+
+
+class TestOverride:
+    @pytest.mark.parametrize("rodne_cislo", sample_of_rc(5))
+    def test_override(self, user, testapp, rodne_cislo):
+        login(user, testapp)
+        res = testapp.get(url_for("donor.detail", rc=rodne_cislo))
+
+        old_first_name = re.search(r"<li>\s*Jméno: (.*)\s*</li>", str(res)).group(1)
+        old_last_name = re.search(r"<li>\s*Příjmení: (.*)\s*</li>", str(res)).group(1)
+
+        # Test save
+        form = res.forms["donorsOverrideForm"]
+        form["first_name"] = "--First--"
+        form["last_name"] = "--Last--"
+        res = form.submit("save_btn").follow()
+
+        assert "Výjimka uložena" in res
+        assert "Jméno: --First--" in res
+        assert "Příjmení: --Last--" in res
+
+        # Test repeated save
+        form = res.forms["donorsOverrideForm"]
+        res = form.submit("save_btn").follow()
+
+        assert "Výjimka uložena" in res
+        assert "Jméno: --First--" in res
+        assert "Příjmení: --Last--" in res
+
+        # Test removing one field's value but keeping the other
+        form = res.forms["donorsOverrideForm"]
+        form["first_name"] = ""
+        res = form.submit("save_btn").follow()
+
+        assert "Výjimka uložena" in res
+        assert ("Jméno: " + old_first_name) in res
+        assert "Příjmení: --Last--" in res
+
+        # Test deleting the override
+        form = res.forms["donorsOverrideForm"]
+        res = form.submit("delete_btn").follow()
+
+        assert "Výjimka smazána" in res
+        assert ("Jméno: " + old_first_name) in res
+        assert ("Příjmení: " + old_last_name) in res

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -1,3 +1,4 @@
+import re
 from random import randint
 
 import pytest
@@ -126,8 +127,8 @@ class TestOverride:
         assert "Příjmení: --Last--" in res
 
         # Test deleting the override
-        form = res.forms["donorsOverrideDeleteForm"]
-        res = form.submit().follow()
+        form = res.forms["donorsOverrideForm"]
+        res = form.submit("delete_btn").follow()
 
         assert "Výjimka smazána" in res
         assert ("Jméno: " + old_first_name) in res

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -126,8 +126,8 @@ class TestOverride:
         assert "Příjmení: --Last--" in res
 
         # Test deleting the override
-        form = res.forms["donorsOverrideForm"]
-        res = form.submit("delete_btn").follow()
+        form = res.forms["donorsOverrideDeleteForm"]
+        res = form.submit().follow()
 
         assert "Výjimka smazána" in res
         assert ("Jméno: " + old_first_name) in res


### PR DESCRIPTION
Přidává možnost přepsat osobní údaje dárce.

Closes #73
Depends on #133

TODO:
 - [x] brát donors_override v úvahu při počítání tabulky donors_overview
 - [x] zvýrazňování dárce s upravenými údaji v seznamu
 - [x] testy
 - [x] upravit layout formuláře
 - [x] samostatný validátor pro PSČ a číslo pojišťovny