### PR TITLE
Odděl závislosti pro lintery do samostatného souboru a přidej Bandit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,10 @@ repos:
     rev: 5.8.0
     hooks:
     -   id: isort
+# Currently there is a bug preventing bandit from
+# excluding folders: https://github.com/PyCQA/bandit/issues/693zzss
+# which we are able to workaround in tox but not here.
+# -   repo: https://github.com/PyCQA/bandit
+#     rev: 1.7.0
+#     hooks:
+#     - id: bandit

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,12 +8,3 @@ WebTest==2.0.35
 # Used to compare calculations we do in SQL with a different approach
 # Using older version because of Python 3.6 support, which pandas > 1.2 doesn't have
 pandas==1.1.5
-
-# Lint and code style
-black==21.5b1
-flake8==3.9.2
-flake8-blind-except==0.2.0
-flake8-debugger==4.0.0
-flake8-isort==4.0.0
-isort==5.8.0
-pep8-naming==0.11.1

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,0 +1,13 @@
+-r dev.txt
+
+# Security scanner
+bandit==1.7.0
+
+# Code checkers, linters and formatters
+black==21.5b1
+flake8==3.9.2
+flake8-blind-except==0.2.0
+flake8-debugger==4.0.0
+flake8-isort==4.0.0
+isort==5.8.0
+pep8-naming==0.11.1

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ deps = -rrequirements/dev.txt
 commands = python -m pytest -v {posargs} tests/
 
 [testenv:lint]
-deps = -rrequirements/dev.txt
+deps = -rrequirements/lint.txt
 commands =
   python -m black --check --diff .
   python -m flake8 .
   python -m isort --check-only .
+  python -m bandit --exclude /tests,/.tox --recursive .


### PR DESCRIPTION
Pro vývoj nejsou lintery potřeba, protože se o jejich spuštění stará pre-commit a tox. Na druhé straně je zbytečné mít v toxu instalované vše i tam, kde se pouští jen lintery. Tak jsem to rozdělil.

Pak jsem přidal Bandit, což je statický analyzátor hledající možné bezpečnostní zranitelnosti.

Přidám ještě jeden dočasný commit, ať je vidět, jak se Bandit chová.