### PR TITLE
Implementace opravy velkých písmen u vstupů s velkými písmeny

### DIFF
--- a/registry/app.py
+++ b/registry/app.py
@@ -1,5 +1,6 @@
 """The app module, containing the app factory function."""
 import logging
+import re
 import sys
 
 from flask import Flask, flash, redirect, url_for
@@ -56,6 +57,17 @@ def create_app(config_object="registry.settings"):
             return word_map[input]
         else:
             return input
+
+    @app.template_filter("capitalize")
+    def capitalize(string):
+        def get_replacement(match):
+            word = match[0]
+            if word.isupper():
+                return word.capitalize()
+            else:
+                return word
+
+        return re.sub(r"\w{2,}", get_replacement, string)
 
     return app
 

--- a/registry/templates/donor/detail.html
+++ b/registry/templates/donor/detail.html
@@ -50,16 +50,16 @@
                 Rodné číslo: {{ overview.rodne_cislo }}
             </div>
             <div class="row">
-                Jméno: {{ overview.first_name }}
+                Jméno: {{ overview.first_name|capitalize }}
             </div>
             <div class="row">
-                Příjmení: {{ overview.last_name }}
+                Příjmení: {{ overview.last_name|capitalize }}
             </div>
             <div class="row">
-                Adresa: {{ overview.address }}
+                Adresa: {{ overview.address|capitalize }}
             </div>
             <div class="row">
-                Město: {{ overview.city }}
+                Město: {{ overview.city|capitalize }}
             </div>
             <div class="row">
                 PSČ: {{ overview.postal_code }}

--- a/tests/test_donor.py
+++ b/tests/test_donor.py
@@ -145,6 +145,7 @@ class TestIgnore:
 class TestOverride:
     @pytest.mark.parametrize("rodne_cislo", sample_of_rc(5))
     def test_override(self, user, testapp, rodne_cislo):
+        skip_if_ignored(rodne_cislo)
         login(user, testapp)
         res = testapp.get(url_for("donor.detail", rc=rodne_cislo))
 
@@ -196,6 +197,7 @@ class TestOverride:
 
     @pytest.mark.parametrize("rodne_cislo", sample_of_rc(1))
     def test_incorrect_override(self, user, testapp, rodne_cislo):
+        skip_if_ignored(rodne_cislo)
         login(user, testapp)
         res = testapp.get(url_for("donor.detail", rc=rodne_cislo))
         form = res.forms["donorsOverrideForm"]
@@ -210,6 +212,7 @@ class TestOverride:
 
     @pytest.mark.parametrize("rodne_cislo", sample_of_rc(1))
     def test_form_errors(self, user, testapp, rodne_cislo):
+        skip_if_ignored(rodne_cislo)
         login(user, testapp)
         res = testapp.get(url_for("donor.detail", rc=rodne_cislo))
         form = res.forms["donorsOverrideForm"]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -68,3 +68,30 @@ class TestNumericValidator:
         validator = NumericValidator(1)
         with pytest.raises(ValidationError, match="^Pole musí mít právě 1 znak$"):
             validator(form, form.field)
+
+
+class TestCapitalizer:
+    @pytest.mark.parametrize(
+        ("input", "expected"),
+        (
+            ("karlov", "karlov"),
+            ("Karlov", "Karlov"),
+            ("KARLOV", "Karlov"),
+            ("Velké KARLOVICE", "Velké Karlovice"),
+            ("velké karlovice", "velké karlovice"),
+            ("VELKÉ karlovice", "Velké karlovice"),
+            ("VELKÉ KARLOVICE", "Velké Karlovice"),
+            ("a b c d", "a b c d"),
+            ("A B C D", "A B C D"),
+            ("a B c D", "a B c D"),
+            ("U LÍPY", "U Lípy"),
+            ("u lípy", "u lípy"),
+            ("U Lípy", "U Lípy"),
+            ("Frýdlant nad Ostravicí", "Frýdlant nad Ostravicí"),
+            ("FRÝDLANT NAD OSTRAVICÍ", "Frýdlant Nad Ostravicí"),
+        ),
+    )
+    def test_capitalize(self, testapp, input, expected):
+        capitalize = testapp.app.jinja_env.filters["capitalize"]
+        output = capitalize(input)
+        assert output == expected


### PR DESCRIPTION
Fixes: https://github.com/frenzymadness/donors_registry/issues/78

V podstatě jde o to najít slova psaná velkými písmeny a každé z nich opravit. Pokud není celé velkými písmeny, necháme to tak jak to je.

@Glutexo napadá tě, jak tohle rozbít? Jakože perfektní to není a nebude, ale pro zlepšení aktuálního stavu, kdy jsou všechna písmena ve vstupních datech někdy velká, to snad postačí.