### PR TITLE
Add a new "send mass e-mail button" to award preps

### DIFF
--- a/registry/donor/views.py
+++ b/registry/donor/views.py
@@ -410,6 +410,13 @@ def award_prep(medal_slug):
     award_medal_form = AwardMedalForm()
     award_medal_form.add_checkboxes([d.rodne_cislo for d in donors])
     print_envelope_labels_form = PrintEnvelopeLabelsForm()
+
+    all_emails = list()
+    for donor in donors:
+        if donor.note:
+            if emails := donor.note.get_emails_from_note():
+                all_emails.extend(emails)
+
     return render_template(
         "donor/award_prep.html",
         medal=medal,
@@ -417,6 +424,7 @@ def award_prep(medal_slug):
         award_medal_form=award_medal_form,
         override_column_names=json.dumps(DonorsOverview.basic_fields),
         print_envelope_labels_form=print_envelope_labels_form,
+        all_emails=all_emails,
     )
 
 

--- a/registry/templates/donor/award_prep.html
+++ b/registry/templates/donor/award_prep.html
@@ -27,6 +27,27 @@
         Stáhnout tabulku pro odběrná místa
     </a>
 </div>
+<div>
+    <a href="mailto:darci@cckfm.cz
+    ?cc=predseda@cckfm.cz
+    &bcc={{all_emails|join(',')}}
+    &subject={{'Pozvánka na slavnostní ocenění dárců krve a krevních složek'|urlencode}}
+    &body={{'Dobrý den,
+
+    v příloze naleznete pozvánku ke slavnostnímu ocenění bezpříspěvkových dárců krve a krevních složek.
+    Prosíme o potvrzení účasti odpovědí na tento e-mail.
+
+    Děkujeme za Vaši pomoc a těšíme se na setkání!
+
+    S úctou
+    Hana Kaňová
+    Český červený kříž – Frýdek-Místek'|urlencode}}"
+        class="btn btn-primary"
+        role="button"
+        target="_blank">
+        Odeslat hromadný e-mail
+    </a>
+</div>
 {% with form=award_medal_form %}
 <form id="awardMedalForm" action="{{ url_for('donor.award_medal') }}" method="POST" class="form-inline" role="form">
     {{ form.csrf_token }}


### PR DESCRIPTION
The button allows to easily send a mass invitation e-mails via local e-mail client.